### PR TITLE
throwOnFail feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # await-maven-plugin
 
-| service | master  | dev |
-| :---: | :---: | :---: |
-| CI Build | [![Build Status](https://semaphoreci.com/api/v1/slem1/await-maven-plugin/branches/master/shields_badge.svg)](https://semaphoreci.com/slem1/await-maven-plugin)  | [![Build Status](https://semaphoreci.com/api/v1/slem1/await-maven-plugin/branches/dev/shields_badge.svg)](https://semaphoreci.com/slem1/await-maven-plugin)  |
-| Test | [![Coverage Status](https://coveralls.io/repos/github/slem1/await-maven-plugin/badge.svg?branch=master)](https://coveralls.io/github/slem1/await-maven-plugin?branch=master) | [![Coverage Status](https://coveralls.io/repos/github/slem1/await-maven-plugin/badge.svg?branch=dev)](https://coveralls.io/github/slem1/await-maven-plugin?branch=dev)  |
+| service  |                                                                                    master                                                                                    |                                                                                  dev                                                                                   |
+| :------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| CI Build |        [![Build Status](https://semaphoreci.com/api/v1/slem1/await-maven-plugin/branches/master/shields_badge.svg)](https://semaphoreci.com/slem1/await-maven-plugin)        |      [![Build Status](https://semaphoreci.com/api/v1/slem1/await-maven-plugin/branches/dev/shields_badge.svg)](https://semaphoreci.com/slem1/await-maven-plugin)       |
+|   Test   | [![Coverage Status](https://coveralls.io/repos/github/slem1/await-maven-plugin/badge.svg?branch=master)](https://coveralls.io/github/slem1/await-maven-plugin?branch=master) | [![Coverage Status](https://coveralls.io/repos/github/slem1/await-maven-plugin/badge.svg?branch=dev)](https://coveralls.io/github/slem1/await-maven-plugin?branch=dev) |
 
 await-maven-plugin is a plugin to pause maven build until some service is available.
 
@@ -39,24 +39,24 @@ await-maven-plugin is a plugin to pause maven build until some service is availa
                             <url>http://mywebservice:9090</url>
                             <statusCode>200</statusCode>
                         </httpConnection>
-                    </httpConnections>    
+                    </httpConnections>
                 </configuration>
             </plugin>
 
 ```
 
 With the above configuration, the maven build will pause after process-test-classes and wait for the availability of
-two services: 
+two services:
 
-  - a tcp service on localhost:5432 (postgres)
-  - a 200 OK http response from http://mywebservice:9090.
+- a tcp service on localhost:5432 (postgres)
+- a 200 OK http response from http://mywebservice:9090.
 
 The plugin will make 3 attempts on to reach each service, waiting 1000ms between each try.
 
 ## Parameters description
 
-
 ### awaitSkip
+
 Set to true if you want to skip plugin execution. Can also be passed as -DawaitSkip
 
 ```xml
@@ -64,6 +64,7 @@ Set to true if you want to skip plugin execution. Can also be passed as -DawaitS
 ```
 
 ### poll
+
 The polling configuration object. Apply to each service to contact.
 
 ```xml
@@ -74,6 +75,7 @@ The polling configuration object. Apply to each service to contact.
 ```
 
 #### attempts
+
 Max number of attempts to reach a service.
 
 ```xml
@@ -81,16 +83,27 @@ Max number of attempts to reach a service.
 ```
 
 #### sleep
+
 Time to wait (in ms) between two attempts.
 
 ```xml
      <sleep>1000</sleep>
 ```
 
+#### throwOnFail
+
+Default behaviour is to throw an exception if all attemps fail. You can override this with the throwOnFail setting. This is usefull when you run services in a docker container and need a cleanup step in the 'post-integration-test' phase.
+
+```xml
+     <throwOnFail>false<throwOnFail>
+```
+
 ### tcpConnections
+
 A collection of tcpConnection elements.
 
 #### tcp
+
 A tcp connection configuration.
 
 ```xml
@@ -103,6 +116,7 @@ A tcp connection configuration.
 ##### host
 
 The tcp host.
+
 ```xml
     <host>localhost</host>
 ```
@@ -110,6 +124,7 @@ The tcp host.
 ##### port
 
 The tcp port.
+
 ```xml
     <port>5432</port>
 ```
@@ -117,7 +132,8 @@ The tcp port.
 ##### priority
 
 Defines the order in which the connection will be attempted across tcpConnection and httpConnection. The 0 value is the highest priority.
-By default, if not defined, the priority is the lowest (Integer.MAX_VALUE). 
+By default, if not defined, the priority is the lowest (Integer.MAX_VALUE).
+
 ```xml
     <priority>100</priority>
 ```
@@ -129,15 +145,18 @@ A collection of http or https connections.
 #### httpConnection
 
 The configuration of a connection to a service running on http.
+
 ```xml
   <httpConnection>
     <url>http://mywebservice:9090</url>
     <statusCode>200</statusCode>
   </httpConnection>
 ```
+
 ##### url
 
 The service URL.
+
 ```xml
   <url>http://mywebservice:9090</url>
 ```
@@ -145,6 +164,7 @@ The service URL.
 ##### statusCode
 
 The expected status code response.
+
 ```xml
    <statusCode>200</statusCode>
 ```
@@ -152,7 +172,8 @@ The expected status code response.
 ##### priority
 
 Defines the order in which the connection will be attempted across tcpConnection and httpConnection. The 0 value is the highest priority.
-By default, if not defined, the priority is the lowest (Integer.MAX_VALUE). 
+By default, if not defined, the priority is the lowest (Integer.MAX_VALUE).
+
 ```xml
     <priority>100</priority>
 ```
@@ -215,7 +236,7 @@ Wait for a docker container startup and service up with docker-compose-maven-plu
                     </httpConnections>
                 </configuration>
             </plugin>
-        </plugins> 
+        </plugins>
  </build>
- 
- ```
+
+```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Time to wait (in ms) between two attempts.
 
 #### throwOnFail
 
-Default behaviour is to throw an exception if all attemps fail. You can override this with the throwOnFail setting. This is usefull when you run services in a docker container and need a cleanup step in the 'post-integration-test' phase.
+Default behaviour is to throw an exception if all attemps fail. You can override this with the throwOnFail setting. This is useful when you run services in a docker container and need a cleanup step in the 'post-integration-test' phase.
 
 ```xml
      <throwOnFail>false<throwOnFail>

--- a/src/main/java/com/github/slem1/await/HttpService.java
+++ b/src/main/java/com/github/slem1/await/HttpService.java
@@ -52,6 +52,7 @@ public class HttpService implements Service {
      *
      * @param url        the url of the service to connect to.
      * @param statusCode the expected http response status code.
+     * @param skipSSLCertVerification true if you want to skip SSL certificate verification.
      */
     public HttpService(URL url, Integer statusCode, boolean skipSSLCertVerification) {
 

--- a/src/main/java/com/github/slem1/await/HttpService.java
+++ b/src/main/java/com/github/slem1/await/HttpService.java
@@ -1,14 +1,15 @@
 package com.github.slem1.await;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Handler for testing connection to remote service on http.

--- a/src/main/java/com/github/slem1/await/MojoEntryPoint.java
+++ b/src/main/java/com/github/slem1/await/MojoEntryPoint.java
@@ -108,7 +108,7 @@ public class MojoEntryPoint extends AbstractMojo {
             Service service = config.buildService();
             PollingTask task = new PollingTask(service,
                     pollingConfig.getAttempts(),
-                    pollingConfig.getSleep(), config.getPriority());
+                    pollingConfig.getSleep(), config.getPriority(), pollingConfig.isThrowOnFail());
             pollingTasks.add(task);
         }
 

--- a/src/main/java/com/github/slem1/await/MojoEntryPoint.java
+++ b/src/main/java/com/github/slem1/await/MojoEntryPoint.java
@@ -1,16 +1,15 @@
 package com.github.slem1.await;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.sonatype.inject.Parameters;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
 
 /**
  * The plugin entry point. Retrieves the plugin configuration and runs the underlying tasks.

--- a/src/main/java/com/github/slem1/await/PollingConfig.java
+++ b/src/main/java/com/github/slem1/await/PollingConfig.java
@@ -11,6 +11,7 @@ public class PollingConfig {
 
     private int sleep = 1000;
 
+    private boolean throwOnFail = true;
     /**
      * Default constructor used by maven
      */
@@ -23,11 +24,14 @@ public class PollingConfig {
      *
      * @param attempts the max number of connection attempts.
      * @param sleep    the waiting time in ms.
+     * @param throwOnFail true to throw if all attempts are unsuccessfull, false will just log it 
+     * 
      */
-    public PollingConfig(int attempts, int sleep) {
+    public PollingConfig(int attempts, int sleep, boolean throwOnFail) {
         validate(attempts, sleep);
         this.attempts = attempts;
         this.sleep = sleep;
+        this.throwOnFail = throwOnFail;
     }
 
     /**
@@ -46,6 +50,15 @@ public class PollingConfig {
      */
     public int getSleep() {
         return sleep;
+    }
+
+    /**
+     * Return if we should throw exception when all attempts fail.
+     *
+     * @return true if we should throw exception
+     */
+    public boolean isThrowOnFail() {
+        return throwOnFail;
     }
 
     /**

--- a/src/main/java/com/github/slem1/await/PollingTask.java
+++ b/src/main/java/com/github/slem1/await/PollingTask.java
@@ -22,6 +22,8 @@ public class PollingTask {
 
     private final Service service;
 
+    private final boolean throwOnFail;
+
     /**
      * Configure the polling runner for the service {@code service}.
      *
@@ -29,8 +31,9 @@ public class PollingTask {
      * @param maxAttempt the maximum number of attempts to run a service.
      * @param waitTime   the waiting time between two attempts.
      * @param priority   the priority of the this task.
+     * @param throwOnFail true if we should throw exception on failure and false if we should log it.
      */
-    PollingTask(final Service service, int maxAttempt, final int waitTime, final int priority) {
+    PollingTask(final Service service, int maxAttempt, final int waitTime, final int priority, final boolean throwOnFail) {
 
         if (service == null) {
             throw new IllegalArgumentException("Service is mandatory");
@@ -44,7 +47,7 @@ public class PollingTask {
             throw new IllegalArgumentException("waitTime value cannot be negative");
         }
 
-        if(priority < 0){
+        if (priority < 0) {
             throw new IllegalArgumentException("priority value must be equals or greater than 0");
         }
 
@@ -52,6 +55,16 @@ public class PollingTask {
         this.maxAttempt = maxAttempt;
         this.waitTime = waitTime;
         this.priority = priority;
+        this.throwOnFail = throwOnFail;
+    }
+
+    /**
+     * Set the logger, for testing
+     *
+     * @param logger the instance of log
+     */
+    public static void setLog(Log logger) {
+        log = logger;
     }
 
     /**
@@ -61,6 +74,15 @@ public class PollingTask {
      */
     public int getPriority() {
         return priority;
+    }
+
+    /**
+     * Returns if we should throw exception on fail or not
+     *
+     * @return true and we throw, false we just log it
+     */
+    public boolean isThrowOnFail() {
+        return throwOnFail;
     }
 
     /**
@@ -90,9 +112,11 @@ public class PollingTask {
 
         } while (n < maxAttempt);
 
-        throw new MojoFailureException(String.format("Service unreachable after %d attempts: %s",
-                maxAttempt, service));
-
+        String errorMsg = String.format("Service unreachable after %d attempts: %s", maxAttempt, service);
+        if (isThrowOnFail()) {
+            throw new MojoFailureException(errorMsg);
+        } else {
+            log.error(errorMsg);
+        }
     }
-
 }

--- a/src/main/java/com/github/slem1/await/PollingTaskExecutor.java
+++ b/src/main/java/com/github/slem1/await/PollingTaskExecutor.java
@@ -1,9 +1,9 @@
 package com.github.slem1.await;
 
+import java.util.List;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-
-import java.util.List;
 
 public class PollingTaskExecutor {
 

--- a/src/test/java/com/github/slem1/await/HttpConnectionConfigTest.java
+++ b/src/test/java/com/github/slem1/await/HttpConnectionConfigTest.java
@@ -1,12 +1,12 @@
 package com.github.slem1.await;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.net.MalformedURLException;
-import java.net.URL;
 
 @RunWith(JUnit4.class)
 public class HttpConnectionConfigTest {

--- a/src/test/java/com/github/slem1/await/HttpServiceTest.java
+++ b/src/test/java/com/github/slem1/await/HttpServiceTest.java
@@ -1,18 +1,19 @@
 package com.github.slem1.await;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
 
-import javax.net.ssl.HttpsURLConnection;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static org.mockito.Mockito.when;
+import javax.net.ssl.HttpsURLConnection;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
 
 @RunWith(JUnit4.class)
 public class HttpServiceTest {

--- a/src/test/java/com/github/slem1/await/MojoEntryPointTest.java
+++ b/src/test/java/com/github/slem1/await/MojoEntryPointTest.java
@@ -1,5 +1,15 @@
 package com.github.slem1.await;
 
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.Assert;
@@ -9,16 +19,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
-
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collections;
-
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(JUnit4.class)
 public class MojoEntryPointTest {

--- a/src/test/java/com/github/slem1/await/MojoEntryPointTest.java
+++ b/src/test/java/com/github/slem1/await/MojoEntryPointTest.java
@@ -23,7 +23,7 @@ import org.mockito.Mockito;
 @RunWith(JUnit4.class)
 public class MojoEntryPointTest {
 
-    private static final PollingConfig POLLING_TEST_CONFIG = new PollingConfig(3, 1);
+    private static final PollingConfig POLLING_TEST_CONFIG = new PollingConfig(3, 1, true);
 
     private MojoEntryPoint mojoEntryPoint;
 

--- a/src/test/java/com/github/slem1/await/PollingConfigTest.java
+++ b/src/test/java/com/github/slem1/await/PollingConfigTest.java
@@ -13,19 +13,22 @@ public class PollingConfigTest {
         PollingConfig pollingConfig = new PollingConfig();
         Assert.assertEquals(3, pollingConfig.getAttempts());
         Assert.assertEquals(1000, pollingConfig.getSleep());
+        Assert.assertTrue(pollingConfig.isThrowOnFail());
+        
     }
 
     @Test
     public void shouldCreateInstanceWithUserValue() {
-        PollingConfig pollingConfig = new PollingConfig(10, 2000);
+        PollingConfig pollingConfig = new PollingConfig(10, 2000, false);
         Assert.assertEquals(10, pollingConfig.getAttempts());
         Assert.assertEquals(2000, pollingConfig.getSleep());
+        Assert.assertFalse(pollingConfig.isThrowOnFail());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowIfMaxAttemptLowerThan1() {
         try {
-            new PollingConfig(0, 2000);
+            new PollingConfig(0, 2000, true);
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("attempts must be >= 1", e.getMessage());
             throw e;
@@ -35,7 +38,7 @@ public class PollingConfigTest {
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowIfSleepIsNegative() {
         try {
-            new PollingConfig(10, -1);
+            new PollingConfig(10, -1, true);
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("sleep cannot be negative", e.getMessage());
             throw e;

--- a/src/test/java/com/github/slem1/await/PollingTaskTest.java
+++ b/src/test/java/com/github/slem1/await/PollingTaskTest.java
@@ -1,13 +1,13 @@
 package com.github.slem1.await;
 
+import java.io.IOException;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.io.IOException;
 
 @RunWith(JUnit4.class)
 public class PollingTaskTest {

--- a/src/test/java/com/github/slem1/await/TCPServiceTest.java
+++ b/src/test/java/com/github/slem1/await/TCPServiceTest.java
@@ -1,14 +1,15 @@
 package com.github.slem1.await;
 
 
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import javax.net.ServerSocketFactory;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import javax.net.ServerSocketFactory;
-import java.io.IOException;
-import java.net.ServerSocket;
 
 @RunWith(JUnit4.class)
 public class TCPServiceTest {


### PR DESCRIPTION
I added a feature such that you can override the default behaviour when all attempts to connect fail. This is useful in a docker/CI setting where you need to do some cleanup like removing networks and volumes.
If the plugin throws an exception maven will stop the execution and a post-integration-test will not be executed. With this setting you can disable this and make the build continue. A log will still be issued that all attempt failed but your integration-tests will of cause also fail.