### PR TITLE
Add ability to specify user and password in url for basic auth as described in rfc7617

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ The service URL.
   <url>http://mywebservice:9090</url>
 ```
 
+The service URL can include basic auth information when running on http
+```xml
+  <url>http://user:pass@mywebservice:9090</url>
+```
+
 ##### statusCode
 
 The expected status code response.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.slem1</groupId>
     <artifactId>await-maven-plugin</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.1</version>
 
     <packaging>maven-plugin</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.slem1</groupId>
     <artifactId>await-maven-plugin</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
 
     <packaging>maven-plugin</packaging>
 
@@ -26,6 +26,7 @@
         <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jaxb-api.version>2.1.9</jaxb-api.version>
     </properties>
 
     <scm>
@@ -47,6 +48,12 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven-plugin-api.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>sun-jaxb</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb-api.version}</version>
         </dependency>
 
         <dependency>
@@ -176,7 +183,7 @@
             </plugin>
         </plugins>
     </build>
-
+    
     <licenses>
         <license>
             <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,6 @@
             </plugin>
         </plugins>
     </build>
-    
     <licenses>
         <license>
             <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <licenses>
         <license>
             <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,7 @@
             </plugin>
         </plugins>
     </build>
+    
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/com/github/slem1/await/HttpService.java
+++ b/src/main/java/com/github/slem1/await/HttpService.java
@@ -4,9 +4,11 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
@@ -87,6 +89,12 @@ public class HttpService implements Service {
             } else {
                 urlConnection = (HttpURLConnection) url.openConnection();
                 urlConnection.setRequestProperty("method", "GET");
+                if(null != url.getUserInfo()){
+                    urlConnection.setRequestProperty("Authorization",
+                        String.format("Basic %s", DatatypeConverter.printBase64Binary(
+                            url.getUserInfo().getBytes(StandardCharsets.UTF_8)
+                    )));
+                }
             }
             urlConnection.connect();
 

--- a/src/test/java/com/github/slem1/await/HttpServiceTest.java
+++ b/src/test/java/com/github/slem1/await/HttpServiceTest.java
@@ -12,6 +12,8 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 @RunWith(JUnit4.class)
@@ -26,6 +28,22 @@ public class HttpServiceTest {
         when(url.getProtocol()).thenReturn("http");
         HttpService httpService = new HttpService(url, 200, false);
         httpService.execute();
+    }
+
+    @Test
+    public void shouldConnectAndGet200_HTTP_With_AuthInfo() throws IOException, ServiceUnavailableException {
+        String authInfo = "user:pass";
+        String expectedPropertyKey = "Authorization";
+        String expectedPropertyValue = "Basic dXNlcjpwYXNz";
+        URL url = Mockito.mock(URL.class);
+        HttpURLConnection urlConnection = Mockito.mock(HttpURLConnection.class);
+        when(urlConnection.getResponseCode()).thenReturn(200);
+        when(url.openConnection()).thenReturn(urlConnection);
+        when(url.getProtocol()).thenReturn("http");
+        when(url.getUserInfo()).thenReturn(authInfo);
+        HttpService httpService = new HttpService(url, 200, false);
+        httpService.execute();
+        Mockito.verify(urlConnection, times(1)).setRequestProperty(eq(expectedPropertyKey), eq(expectedPropertyValue));
     }
 
     @Test
@@ -49,6 +67,7 @@ public class HttpServiceTest {
         HttpService httpService = new HttpService(url, 200, false);
         httpService.execute();
     }
+
 
     @Test(expected = ServiceUnavailableException.class)
     public void shouldThrowServiceUnavailableException_HTTP() throws IOException, ServiceUnavailableException {

--- a/src/test/java/com/github/slem1/await/HttpServiceTest.java
+++ b/src/test/java/com/github/slem1/await/HttpServiceTest.java
@@ -68,7 +68,6 @@ public class HttpServiceTest {
         httpService.execute();
     }
 
-
     @Test(expected = ServiceUnavailableException.class)
     public void shouldThrowServiceUnavailableException_HTTP() throws IOException, ServiceUnavailableException {
         URL url = Mockito.mock(URL.class);


### PR DESCRIPTION
Adds the ability to specify user and password in url for basic auth as described in rfc7617.

This will allow a URL formatted http://user:pass@localhost:9200 to submit user and pass as Basic Authorization on connection attempts. 

For example http://user:pass@localhost:9200 this would make a call to localhost port 9200, and it would set the Request Header "Authorization" to "Basic dXNlcjpwYXNz" allowing the client to authenticate. 